### PR TITLE
Update Activation Bit Width 

### DIFF
--- a/workspace/src_jet/code/model.py
+++ b/workspace/src_jet/code/model.py
@@ -38,7 +38,7 @@ def load_checkpoint(args, file_name):
     
     result = re.search('JT_(.*)b', args.arch)
     quant = int(result.group(1))
-    fake = ArgFake(w=quant,b=quant,a=quant)
+    fake = ArgFake(w=quant,b=quant,a=quant+3)
     
     
     checkpoint = torch.load(file_name, map_location=torch.device("cpu"))


### PR DESCRIPTION
### Changes
This PR updates the activation bit width (B<sub>a</sub>) in _model.py_. The quantization scheme for activations is B<sub>w</sub> + 3, where B<sub>w</sub> is the bit width for weights and biases. 

Model used for training:
```
QThreeLayer(
  (quant_input): QuantAct(activation_bit=9, full_precision_flag=False, quant_mode=symmetric, Act_min: 0.00, Act_max: 0.00)
  (dense_1): (QuantLinear() weight_bit=6, full_precision_flag=False, quantize_fn=symmetric)
  (quant_act_1): QuantAct(activation_bit=9, full_precision_flag=False, quant_mode=symmetric, Act_min: 0.00, Act_max: 0.00)
  (dense_2): (QuantLinear() weight_bit=6, full_precision_flag=False, quantize_fn=symmetric)
  (quant_act_2): QuantAct(activation_bit=9, full_precision_flag=False, quant_mode=symmetric, Act_min: 0.00, Act_max: 0.00)
  (dense_3): (QuantLinear() weight_bit=6, full_precision_flag=False, quantize_fn=symmetric)
  (quant_act_3): QuantAct(activation_bit=9, full_precision_flag=False, quant_mode=symmetric, Act_min: 0.00, Act_max: 0.00)
  (dense_4): (QuantLinear() weight_bit=6, full_precision_flag=False, quantize_fn=symmetric)
  (act): ReLU()
  (softmax): Softmax(dim=1)
)
```

But the quantized model used for metrics defines the activation bitwidth as the same as the weights. [Source](https://github.com/ben-hawks/loss_landscape_taxonomy/blob/main/workspace/src_jet/code/model.py#L39-L41).  
```
result = re.search('JT_(.*)b', args.arch)
quant = int(result.group(1))
fake = ArgFake(w=quant,b=quant,a=quant)
```

### Results
Accuracy for each model with updated bit settings running loss_acc.py 
(Learning rate is 0.1)
```
0:{'nll': 34.68304779663086, 'loss': 34.68304779663086, 'accuracy': 0.7202208333333333}
1:{'nll': 34.26182012532552, 'loss': 34.26182012532552, 'accuracy': 0.7214458333333333}
2:{'nll': 39.10882179260254, 'loss': 39.10882179260254, 'accuracy': 0.678825}
3:{'nll': 40.53889730122884, 'loss': 40.53889730122884, 'accuracy': 0.6605208333333333}
4:{'nll': 34.03135023295085, 'loss': 34.03135023295085, 'accuracy': 0.7238166666666667}
```